### PR TITLE
Resolve: Use only required params in RouteData #43

### DIFF
--- a/src/lib/items/RouteData.php
+++ b/src/lib/items/RouteData.php
@@ -189,7 +189,6 @@ final class RouteData extends BaseObject
             if (array_key_exists($paramName, $pathParameters)) {
                 //$additional = $pathParameters[$paramName]->schema->additionalProperties ?? null;
                 $this->params[$paramName] = [
-                    //@TODO: use only required params
                     //'required'=> $pathParameters[$paramName]->required,
                     'type' => $pathParameters[$paramName]->schema->type ?? null,
                     //'model' => $additional ? SchemaResponseResolver::guessModelByRef($additional) : null,


### PR DESCRIPTION
Fixes #43 

---

It seems like there is nothing to do here.

For schema:

```yaml
  /pets/{id}:
    get:
      summary: Info for a specific pet
      operationId: showPetById
      tags:
        - pets
      parameters:
        - name: id
          in: path
          required: false <---------------------------------------------------------------- here
          description: The id of the pet to retrieve
          schema:
            type: string
```

if params is not required then we get validation error:

```
Array
(
    [openApiPath] => Array
        (
            [0] => Failed to validate OpenAPI spec:<ul>
<li>[/paths/~1pets~1{id}/get/parameters/1] Parameter &#039;required&#039; must be true for &#039;in&#039;: &#039;path&#039;.</li>
</ul>
        )

)
```

and code generation fails.