### PR TITLE
nonDbFakerStub on items with ref

### DIFF
--- a/src/lib/FakerStubResolver.php
+++ b/src/lib/FakerStubResolver.php
@@ -373,7 +373,10 @@ class FakerStubResolver
      * Re-indents a compact wrapInArray() output string to match the correct depth inside fakeForObject().
      * wrapInArray() always uses hardcoded 12/8-space indentation; when its result is embedded as a
      * property value inside a fakeForObject() output, the indentation must be adjusted.
-     * For a nested array_map body the inner call is expanded to multi-line style via expandCompactArrayMap().
+     *
+     * For a simple body (single return statement): shift = bodyIndent - 12, placing the return at bodyIndent.
+     * For a nested body (return array_map(...)): shift = bodyIndent - 8, so the inner return lands at
+     * bodyIndent+4 and the inner closing brace lands at bodyIndent — matching wrapInArray's 12/8 ratio.
      */
     private function reindentArrayMapForObject(string $code, int $depth): string
     {
@@ -386,45 +389,17 @@ class FakerStubResolver
         }
         [$body, $count] = [$m[1], $m[2]];
 
-        // Shift all continuation lines by the delta between the target indent and wrapInArray's hardcoded 12 spaces.
-        $shift = strlen($bodyIndent) - 12;
+        // For nested array_map: wrapInArray places the inner return at 12 spaces and the inner closing
+        // brace at 8 spaces. We want the inner return at bodyIndent+4 and the inner brace at bodyIndent,
+        // so the shift is bodyIndent - 8. For simple (non-nested) bodies the shift is bodyIndent - 12.
+        $shift = strlen($bodyIndent) - (str_starts_with($body, 'return array_map(') ? 8 : 12);
         if ($shift > 0) {
             $body = preg_replace('/\n/', "\n" . str_repeat(' ', $shift), $body);
-        }
-
-        if (str_starts_with($body, 'return array_map(')) {
-            $inner    = substr($body, 7, -1); // strip "return " prefix and trailing ";"
-            $expanded = $this->expandCompactArrayMap($inner, $bodyIndent);
-            return "array_map(function () use (\$faker, \$uniqueFaker) {\n"
-                . $bodyIndent  . "return {$expanded};\n"
-                . $closeIndent . "}, range(1, {$count}))";
         }
 
         return "array_map(function () use (\$faker, \$uniqueFaker) {\n"
             . $bodyIndent  . $body . "\n"
             . $closeIndent . "}, range(1, {$count}))";
-    }
-
-    /**
-     * Expands a compact wrapInArray() string (single-line function + range) into multi-line style,
-     * using $baseIndent as the reference indentation level for the opening "array_map(" line.
-     */
-    private function expandCompactArrayMap(string $code, string $baseIndent): string
-    {
-        $pat = '/^array_map\(function \(\) use \(\$faker, \$uniqueFaker\) \{\n            (.*)\n        \}, range\(1, (\d+)\)\)$/s';
-        if (!preg_match($pat, $code, $m)) {
-            return $code;
-        }
-        [$body, $count] = [$m[1], $m[2]];
-        $funcIndent  = $baseIndent . '    ';
-        $innerIndent = $baseIndent . '        ';
-
-        return "array_map(\n"
-            . $funcIndent  . "function () use (\$faker, \$uniqueFaker) {\n"
-            . $innerIndent . $body . "\n"
-            . $funcIndent  . "},\n"
-            . $funcIndent  . "range(1, {$count})\n"
-            . $baseIndent  . ")";
     }
 
     /**
@@ -449,13 +424,10 @@ class FakerStubResolver
 
             $inp = $aDataType instanceof Reference ? $aDataType : ['items' => $aDataType->getSerializableData()];
             $aFaker = $this->aElementFaker($inp, $this->attribute->columnName);
-            /**
-             * Each $dataTypeN gets its own line (12-space indent = wrapInArray body level).
-             * wrapInArray output (array_map) gets +4 spaces on continuation lines (12→16, 8→12).
-             * fakeForObject output (starts with "[") is left as-is — depth=1 already gives 16/12.
-             * return goes on its own line.
-             */
-            if (str_contains($aFaker, PHP_EOL) && !str_starts_with($aFaker, '[')) {
+            // Shift all continuation lines by 4 spaces so that multi-line values
+            // (array_map or object literals from fakeForObject) are indented one level
+            // deeper than the $dataTypeN assignment (12 → 16 for body, 8 → 12 for closing).
+            if (str_contains($aFaker, PHP_EOL)) {
                 $aFaker = str_replace(PHP_EOL, PHP_EOL . '    ', $aFaker);
             }
             if ($result !== '') {

--- a/src/lib/FakerStubResolver.php
+++ b/src/lib/FakerStubResolver.php
@@ -80,8 +80,8 @@ class FakerStubResolver
             return null;
         }
 
-        // column name ends with `_id`/FK
-        if (substr($this->attribute->columnName, -3) === '_id' || !empty($this->attribute->fkColName)) {
+        // FK: determined by a $ref / allOf[$ref] — not by column name convention
+        if (!empty($this->attribute->reference)) {
             $config = $this->config;
             if (!$config) {
                 $config = new Config;
@@ -313,7 +313,7 @@ class FakerStubResolver
         }
 
         if ($type === 'object') {
-            $result = $this->fakeForObject($items);
+            $result = $this->fakeForObject($items, 1);
             if ($result === '(object) []') {
                 return '[]';
             }
@@ -339,7 +339,7 @@ class FakerStubResolver
      * defined properties this is acceptable, as no schema is enforced.
      * @internal
      */
-    public function fakeForObject(SpecObjectInterface $items, int $depth = 1): string
+    public function fakeForObject(SpecObjectInterface $items, int $depth = 0): string
     {
         if (!$items->properties) {
             return '(object) []';
@@ -353,14 +353,15 @@ class FakerStubResolver
             /** @var SpecObjectInterface $prop */
 
             if (!$prop instanceof Reference && ($prop->type === 'object' || !empty($prop->properties))) {
+                $key = $name;
                 $result = $this->fakeForObject($prop, $depth + 1);
             } else {
-                $result = $this->aElementFaker(['items' => $prop->getSerializableData()], $name);
+                ['columnName' => $key, 'fakerStub' => $result] = $this->resolveElement(['items' => $prop->getSerializableData()], $name);
                 if (str_starts_with($result, 'array_map')) {
                     $result = $this->reindentArrayMapForObject($result, $depth);
                 }
             }
-            $parts[] = $indent . '\'' . $name . '\' => ' . $result . ',';
+            $parts[] = $indent . '\'' . $key . '\' => ' . $result . ',';
         }
 
         $props = '[' . PHP_EOL . implode(PHP_EOL, $parts) . PHP_EOL . $closingIndent . ']';
@@ -371,7 +372,7 @@ class FakerStubResolver
     /**
      * Re-indents a compact wrapInArray() output string to match the correct depth inside fakeForObject().
      * wrapInArray() always uses hardcoded 12/8-space indentation; when its result is embedded as a
-     * property value inside a fakeForObject() output at depth >= 1, the indentation must be adjusted.
+     * property value inside a fakeForObject() output, the indentation must be adjusted.
      * For a nested array_map body the inner call is expanded to multi-line style via expandCompactArrayMap().
      */
     private function reindentArrayMapForObject(string $code, int $depth): string
@@ -385,19 +386,23 @@ class FakerStubResolver
         }
         [$body, $count] = [$m[1], $m[2]];
 
+        // Shift all continuation lines by the delta between the target indent and wrapInArray's hardcoded 12 spaces.
+        $shift = strlen($bodyIndent) - 12;
+        if ($shift > 0) {
+            $body = preg_replace('/\n/', "\n" . str_repeat(' ', $shift), $body);
+        }
+
         if (str_starts_with($body, 'return array_map(')) {
             $inner    = substr($body, 7, -1); // strip "return " prefix and trailing ";"
             $expanded = $this->expandCompactArrayMap($inner, $bodyIndent);
             return "array_map(function () use (\$faker, \$uniqueFaker) {\n"
                 . $bodyIndent  . "return {$expanded};\n"
-                . $closeIndent . "},\n"
-                . $closeIndent . "range(1, {$count}))";
+                . $closeIndent . "}, range(1, {$count}))";
         }
 
         return "array_map(function () use (\$faker, \$uniqueFaker) {\n"
             . $bodyIndent  . $body . "\n"
-            . $closeIndent . "},\n"
-            . $closeIndent . "range(1, {$count}))";
+            . $closeIndent . "}, range(1, {$count}))";
     }
 
     /**
@@ -493,10 +498,21 @@ class FakerStubResolver
      */
     public function aElementFaker($data, ?string $columnName = null): ?string
     {
+        return $this->resolveElement($data, $columnName)['fakerStub'];
+    }
+
+    /**
+     * Resolves the faker stub and the effective column key for a single element.
+     * For FK properties (direct $ref or allOf[$ref]), the key uses the same '_id' suffix
+     * logic as Attribute::asReference() — both for real DB columns and JSONB sub-properties.
+     * @return array
+     * @example ['columnName' => 'payment_method_id', 'fakerStub' => '$faker->randomElement(...)']
+     */
+    private function resolveElement($data, ?string $columnName = null): array
+    {
         if ($data instanceof Reference) {
-            $class = str_replace('#/components/schemas/', '', $data->getReference());
-            $class .= 'Faker';
-            return '(new ' . $class . ')->generateModel()->attributes';
+            $class = str_replace('#/components/schemas/', '', $data->getReference()) . 'Faker';
+            return ['columnName' => $columnName ?? 'unknownColumn', 'fakerStub' => '(new ' . $class . ')->generateModel()->attributes'];
         }
 
         $inp = $data instanceof SpecObjectInterface ? $data->getSerializableData() : $data;
@@ -523,7 +539,11 @@ class FakerStubResolver
             $schema->setReferenceContext($rc);
         }
         $dbModels = (new AttributeResolver($compo, $cs, new JunctionSchemas([]), $this->config))->resolve();
+        $attr = $dbModels->attributes[$columnName];
 
-        return (new static($dbModels->attributes[$columnName], $cs->getProperty($columnName), $this->config))->resolve();
+        return [
+            'columnName' => $attr->columnName,
+            'fakerStub' => (new static($attr, $cs->getProperty($columnName), $this->config))->resolve(),
+        ];
     }
 }

--- a/src/lib/openapi/PropertySchema.php
+++ b/src/lib/openapi/PropertySchema.php
@@ -130,26 +130,20 @@ class PropertySchema
             }
         }
 
-        if (
-            ($onUpdate !== null || $onDelete !== null) &&
-            ($reference instanceof Reference)
-        ) {
-            $this->onUpdateFkConstraint = $onUpdate;
-            $this->onDeleteFkConstraint = $onDelete;
-            $this->property = $reference;
-            $property = $this->property;
-        } elseif (
-            ($fkColName !== null) &&
-            ($reference instanceof Reference)
-        ) {
-            $this->fkColName = $fkColName;
-            $this->property = $reference;
-            $property = $this->property;
-        } elseif ($xFaker !== null && $reference instanceof Reference) {
-            $this->xFaker = $xFaker;
-            $this->property = $reference;
-            $property = $this->property;
-        } elseif ($xDbTypeFalse && $reference instanceof Reference) {
+        if ($reference instanceof Reference) {
+            if ($onUpdate !== null) {
+                $this->onUpdateFkConstraint = $onUpdate;
+            }
+            if ($onDelete !== null) {
+                $this->onDeleteFkConstraint = $onDelete;
+            }
+            if ($fkColName !== null) {
+                $this->fkColName = $fkColName;
+            }
+            if ($xFaker !== null) {
+                $this->xFaker = $xFaker;
+            }
+            // covers: fk constraints, fkColName, xFaker, xDbTypeFalse, and plain allOf[$ref]
             $this->property = $reference;
             $property = $this->property;
         }

--- a/tests/specs/issue_fix/20_consider_openapi_spec_examples_in_faker_code_generation/mysql/models/PetFaker.php
+++ b/tests/specs/issue_fix/20_consider_openapi_spec_examples_in_faker_code_generation/mysql/models/PetFaker.php
@@ -78,24 +78,18 @@ class PetFaker extends BaseModelFaker
                 'id' => $uniqueFaker->numberBetween(0, 1000000),
                 'name' => $faker->sentence,
                 'age' => $faker->numberBetween(0, 200),
-                'user' => $faker->randomElement(\app\models\User::find()->select("id")->column()),
+                'user_id' => $faker->randomElement(\app\models\User::find()->select("id")->column()),
                 'user_2' => array_map(function () use ($faker, $uniqueFaker) {
                     return (new UserFaker)->generateModel()->attributes;
-                },
-                range(1, 4)),
+                }, range(1, 4)),
                 'tags' => array_map(function () use ($faker, $uniqueFaker) {
                     return $uniqueFaker->sentence;
-                },
-                range(1, 4)),
+                }, range(1, 4)),
                 'arr_arr_int_2' => array_map(function () use ($faker, $uniqueFaker) {
-                    return array_map(
-                        function () use ($faker, $uniqueFaker) {
-                            return $faker->numberBetween(0, 1000000);
-                        },
-                        range(1, 11)
-                    );
-                },
-                range(1, 4)),
+                    return array_map(function () use ($faker, $uniqueFaker) {
+                        return $faker->numberBetween(0, 1000000);
+                    }, range(1, 11));
+                }, range(1, 4)),
                 'appearance' => [
                     'height' => $faker->numberBetween(0, 20),
                     'weight' => $faker->numberBetween(0, 1000000),


### PR DESCRIPTION
## Fix: FK faker detection, JSONB sub-property key derivation, and allOf handling

### 1. FK detection via `attribute->reference` instead of `_id` suffix (`FakerStubResolver.php`)
The `_id`-suffix heuristic generated invalid PHP for JSONB sub-properties with a `$ref`
(e.g. `payment_method` → `payment_method_id`, but `attribute->reference` was empty → `\common\models\::find()`).
Now uses `!empty($this->attribute->reference)` — set only when an actual `$ref`/`allOf[$ref]` resolves to a model.

Before (workaround — plain integer, no `$ref`, FK relation not expressed in spec):
```yaml
payment_method_fields:
  type: object
  x-db-type: jsonb
  properties:
    payment_method_id:
      type: integer
```
After (correct — `$ref` used directly, key `payment_method_id` derived automatically):
```yaml
payment_method_fields:
  type: object
  x-db-type: jsonb
  properties:
    payment_method:
      $ref: '../openapi.yaml#/components/schemas/CompanyPaymentMethod'
```
Also works with `allOf` (e.g. to add a description):
```yaml
payment_method_fields:
  type: object
  x-db-type: jsonb
  properties:
    payment_method:
      allOf:
        - $ref: '../openapi.yaml#/components/schemas/CompanyPaymentMethod'
        - description: "Payment method used for this invoice"
```

### 2. New private `resolveElement()` — correct key derivation for JSONB sub-properties (`FakerStubResolver.php`)
`fakeForObject()` used the raw spec property name as key. FK sub-properties now go through
`resolveElement()`, which runs `AttributeResolver` → `Attribute::asReference()` — the same
`_id` suffix logic as for top-level FK columns. Returns both `columnName` and `fakerStub`.
`aElementFaker()` delegates to it.

Using the YAML from point 1, the generated faker code is:
```php
$model->payment_method_fields = [
    'payment_method_id' => $faker->randomElement(\common\models\CompanyPaymentMethod::find()->select("id")->column()),
    // ...
];
```

### 3. `fakeForObject` depth default: 1 → 0; `reindentArrayMapForObject` line shift fixed (`FakerStubResolver.php`)
Default `1` caused wrong indentation for top-level object attributes. Now `0`; `fakeForArray`
explicitly passes `1`. `reindentArrayMapForObject` now shifts all continuation lines (not just
the first), and `}, range(1, n)` is written on one line.

### 4. `allOf` handling: `elseif` chain → independent `if` blocks (`PropertySchema.php`)
The `elseif` chain applied only the first matching optional attribute from an `allOf` entry.
Four independent `if` blocks now apply all present attributes in one pass.